### PR TITLE
Zemismart ZM-CSW032-D Curtain/roller blind switch set position

### DIFF
--- a/to
+++ b/to
@@ -9043,7 +9043,7 @@ const devices = [
         description: 'Curtain/roller blind switch',
         supports: 'open, close, stop',
         fromZigbee: [fz.ignore_basic_report, fz.ZMCSW032D_cover_position_tilt],
-        toZigbee: [tz.cover_state, tz.cover_position_tilt],
+        toZigbee: [tz.cover_state, tz.ZMCSW032D_cover_position_tilt],
         meta: {configureKey: 1, multiEndpoint: true},
         configure: async (device, coordinatorEndpoint) => {
             const endpoint = device.getEndpoint(1);


### PR DESCRIPTION
This update is intended for an interactive movement by definition of the position. Zemismart use the commands "open, close" and not "upOpen, downClose" (define in closuresWindowCovering).
This modification depends on a modification in "zigbee-herdsman" (cluster.js)