### PR TITLE
Zemismart ZM-CSW032-D Curtain/roller blind switch get and set position

### DIFF
--- a/converters/toZigbee.js
+++ b/converters/toZigbee.js
@@ -269,6 +269,45 @@ const converters = {
             await entity.read('closuresWindowCovering', [isPosition ? 'currentPositionLiftPercentage' : 'currentPositionTiltPercentage']);
         },
     },
+    ZMCSW032D_cover_position: {
+        key: ['position', 'tilt'],
+        convertSet: async (entity, key, value, meta) => {
+            if (options.hasOwnProperty('time_close') && options.hasOwnProperty('time_open')) {
+                const sleepSeconds = async (s) => {
+					return new Promise((resolve) => setTimeout(resolve, s * 1000));
+				};
+
+				const oldPosition = meta.state.position;
+				if (value == 100) {
+					await entity.command('closuresWindowCovering', "upOpen", {}, utils.getOptions(meta.mapped));
+				} else if (value == 0) {
+					await entity.command('closuresWindowCovering', "downClose", {}, utils.getOptions(meta.mapped));
+				} else {
+					if (oldPosition > value) {
+						const delta = oldPosition - value;
+						let mutiplicateur = meta.options.time_open/100;
+						const timeBeforeStop = delta*mutiplicateur;
+						await entity.command('closuresWindowCovering', "downClose", {}, utils.getOptions(meta.mapped));
+						await sleepSeconds(timeBeforeStop);
+						await entity.command('closuresWindowCovering', "stop", {}, utils.getOptions(meta.mapped));
+					} else if (oldPosition < value) {
+						const delta = value - oldPosition;
+						let mutiplicateur = meta.options.time_close/100;
+						const timeBeforeStop = delta*mutiplicateur;
+						await entity.command('closuresWindowCovering', "upOpen", {}, utils.getOptions(meta.mapped));
+						await sleepSeconds(timeBeforeStop);
+						await entity.command('closuresWindowCovering', "stop", {}, utils.getOptions(meta.mapped));
+					}
+				}
+
+				return {state: {position: value}};
+			}
+        },
+        convertGet: async (entity, key, meta) => {
+            const isPosition = (key === 'position');
+            await entity.read('closuresWindowCovering', [isPosition ? 'currentPositionLiftPercentage' : 'currentPositionTiltPercentage']);
+        },
+    },
     occupancy_timeout: {
         // Sets delay after motion detector changes from occupied to unoccupied
         key: ['occupancy_timeout'],


### PR DESCRIPTION
For Zemismart ZM-CSW032-D Curtain/roller blind switch get and set position.

It is necessary to add two elements in the "Configuration.yaml". 
For time_close and time_open, here is my configuration in configuration,yaml ;
'0xec1bbdfffeXXXXXX': friendly_name: MyCover time_close: 27 time_open: 28